### PR TITLE
Add task model and service

### DIFF
--- a/src/app/task-data.service.spec.ts
+++ b/src/app/task-data.service.spec.ts
@@ -1,0 +1,95 @@
+import {TestBed, async, inject} from '@angular/core/testing';
+import {Task} from './task';
+import {TaskDataService} from './task-data.service';
+
+describe('TaskDataService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [TaskDataService]
+    });
+  });
+
+  it('should ...', inject([TaskDataService], (service: TaskDataService) => {
+    expect(service).toBeTruthy();
+  }));
+
+  describe('#getAllTasks()', () => {
+    it('should return an empty array by default', inject([TaskDataService], (service: TaskDataService) => {
+      expect(service.getAllTasks()).toEqual([]);
+    }));
+
+    it('should return all tasks', inject([TaskDataService], (service: TaskDataService) => {
+      let task1 = new Task({description: 'description_1', completed: false});
+      let task2 = new Task({description: 'description_2', completed: true});
+      service.addTask(task1);
+      service.addTask(task2);
+      expect(service.getAllTasks()).toEqual([task1, task2]);
+    }));
+  });
+
+  describe('#save(task)', () => {
+    it('should automatically assign an incrementing id', inject([TaskDataService], (service: TaskDataService) => {
+      let task1 = new Task({description: 'description_1', completed: false});
+      let task2 = new Task({description: 'description_2', completed: true});
+      service.addTask(task1);
+      service.addTask(task2);
+      expect(service.getTaskById(1)).toEqual(task1);
+      expect(service.getTaskById(2)).toEqual(task2);
+    }));
+  });
+
+  describe('#deleteTaskById(id)', () => {
+    it('should remove task with the corresponding id', inject([TaskDataService], (service: TaskDataService) => {
+      let task1 = new Task({description: 'description_1', completed: false});
+      let task2 = new Task({description: 'description_2', completed: true});
+      service.addTask(task1);
+      service.addTask(task2);
+      expect(service.getAllTasks()).toEqual([task1, task2]);
+      service.deleteTaskById(1);
+      expect(service.getAllTasks()).toEqual([task2]);
+      service.deleteTaskById(2);
+      expect(service.getAllTasks()).toEqual([]);
+    }));
+
+    it('should not removing anything if task with corresponding id is not found', inject([TaskDataService], (service: TaskDataService) => {
+      let task1 = new Task({description: 'description_1', completed: false});
+      let task2 = new Task({description: 'description_2', completed: true});
+      service.addTask(task1);
+      service.addTask(task2);
+      expect(service.getAllTasks()).toEqual([task1, task2]);
+      service.deleteTaskById(3);
+      expect(service.getAllTasks()).toEqual([task1, task2]);
+    }));
+  });
+
+  describe('#updateTaskById(id, values)', () => {
+    it('should return task with the corresponding id and updated data', inject([TaskDataService], (service: TaskDataService) => {
+      let task = new Task({description: 'description_1', completed: false});
+      service.addTask(task);
+      let updatedTask = service.updateTaskById(1, {
+        description: 'new description'
+      });
+      expect(updatedTask.description).toEqual('new description');
+    }));
+
+    it('should return null if task is not found', inject([TaskDataService], (service: TaskDataService) => {
+      let task = new Task({description: 'description_1', completed: false});
+      service.addTask(task);
+      let updatedTask = service.updateTaskById(2, {
+        description: 'new description'
+      });
+      expect(updatedTask).toEqual(null);
+    }));
+  });
+
+  describe('#toggleTaskCompleted(task)', () => {
+    it('should return the updated task with inverse completed status', inject([TaskDataService], (service: TaskDataService) => {
+      let task = new Task({description: 'description_1', completed: false});
+      service.addTask(task);
+      let updatedTask = service.toggleTaskCompleted(task);
+      expect(updatedTask.completed).toEqual(true);
+      service.toggleTaskCompleted(task);
+      expect(updatedTask.completed).toEqual(false);
+    }));
+  });
+});

--- a/src/app/task-data.service.ts
+++ b/src/app/task-data.service.ts
@@ -1,0 +1,61 @@
+import {Injectable} from '@angular/core';
+import {Task} from './task';
+
+@Injectable()
+export class TaskDataService {
+
+  // Placeholder for last id so we can simulate automatic incrementing of ids
+  lastId: number = 0;
+
+  // Placeholder for tasks
+  tasks: Task[] = [];
+
+  constructor() {}
+
+  // Simulate POST /tasks
+  addTask(task: Task): TaskDataService {
+    if (!task.id) {
+      task.id = ++this.lastId;
+    }
+    this.tasks.push(task);
+    return this;
+  }
+
+  // Simulate DELETE /tasks/:id
+  deleteTaskById(id: number): TaskDataService {
+    this.tasks = this.tasks
+      .filter(task => task.id !== id);
+    return this;
+  }
+
+  // Simulate PUT /tasks/:id
+  updateTaskById(id: number, values: Object = {}): Task {
+    let task = this.getTaskById(id);
+    if (!task) {
+      return null;
+    }
+    Object.assign(task, values);
+    return task;
+  }
+
+  // Simulate GET /tasks
+  getAllTasks(): Task[] {
+    return this.tasks;
+  }
+
+  // Simulate GET /tasks/:id
+  getTaskById(id: number): Task {
+    return this.tasks
+      .filter(task => task.id === id)
+      .pop();
+  }
+
+  // Toggle task completed
+  toggleTaskCompleted(task: Task){
+    let updatedTask = this.updateTaskById(task.id, {
+      completed: !task.completed
+    });
+    return updatedTask;
+  }
+
+}

--- a/src/app/task.spec.ts
+++ b/src/app/task.spec.ts
@@ -1,0 +1,16 @@
+import {Task} from './task';
+
+describe('Task', () => {
+  it('should create an instance', () => {
+    expect(new Task()).toBeTruthy();
+  });
+
+  it('should accept values in the constructor', () => {
+    let task = new Task({
+      description: 'description_1',
+      completed: true
+    });
+    expect(task.description).toEqual('description_1');
+    expect(task.completed).toEqual(true);
+  });
+});

--- a/src/app/task.ts
+++ b/src/app/task.ts
@@ -1,0 +1,9 @@
+export class Task {
+  id: number;
+  description: string = '';
+  completed: boolean = false;
+
+  constructor(values: Object = {}) {
+    Object.assign(this, values);
+  }
+}


### PR DESCRIPTION
## What functionality does this accomplish?
Closes #1 

**Description:**
This PR adds and tests a Task model and service.

## What did you struggle on to complete?
The built-in service generator gave me a problem with `inject` and importing my task model to the service test. I followed a tutorial to get me past this issue.

## Current Test Suite:
```
94% after sealjamescape~/go/task-list-frontend[add_task_model_and_service ?] ng test

30% building 36/36 modules 0 active01 03 2020 13:10:56.118:WARN [karma]: No captured browser, open http://localhost:9876/

01 03 2020 13:10:56.125:INFO [karma-server]: Karma v4.3.0 server started at http://0.0.0.0:9876/

01 03 2020 13:10:56.126:INFO [launcher]: Launching browsers Chrome with concurrency unlimited

30% building 37/37 modules 0 active01 03 2020 13:10:56.148:INFO [launcher]: Starting browser Chrome

01 03 2020 13:11:00.792:WARN [karma]: No captured browser, open http://localhost:9876/
01 03 2020 13:11:00.914:INFO [Chrome 80.0.3987 (Mac OS X 10.14.6)]: Connected on socket yoml6_p25SLfbnnAAAAA with id 46922439

Chrome 80.0.3987 (Mac OS X 10.14.6): Executed 14 of 14 SUCCESS (0.331 secs / 0.229 secs)
TOTAL: 14 SUCCESS
TOTAL: 14 SUCCESS
```

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas

## Helpful Resources:
* I am leaning heavily on this [tutorial](https://www.sitepoint.com/angular-2-tutorial/)